### PR TITLE
Cleanup pom file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,18 +22,26 @@
             <comments>All source code is under the MIT license.</comments>
             <url>https://opensource.org/licenses/MIT</url>
         </license>
-    </licenses>
+    </licenses> 
+
+    <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
+    <scm>
+        <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
+        <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
+        <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
+        <tag>HEAD</tag>
+    </scm>
 
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>
-            <url>https://github.com/jenkinsci/wallarm-fast-plugin</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>
             <id>repo.jenkins-ci.org</id>
-            <url>https://github.com/jenkinsci/wallarm-fast-plugin</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
 </project>


### PR DESCRIPTION
Add in <url> to point to repo for documentation
Add in <scm> so mvn release will push tags/ show up on plugins.jenkins.io
Restore <repositories> so mvn knows where to get dependancies / release to