### PR TITLE
wrap exclude field with double quotes by default. Add quotes if missing

### DIFF
--- a/src/main/java/io/jenkins/plugins/WallarmFastBuilder.java
+++ b/src/main/java/io/jenkins/plugins/WallarmFastBuilder.java
@@ -305,13 +305,18 @@ public class WallarmFastBuilder extends Builder implements SimpleBuildStep {
         if (not_empty(testRunName))             {cmd.add("-e TEST_RUN_NAME="               + testRunName.replace(" ", "_"));}
         if (not_empty(testRunDesc))             {cmd.add("-e TEST_RUN_DESC="               + testRunDesc.replace(" ", "_"));}
         if (not_empty(stopOnFirstFail))         {cmd.add("-e TEST_RUN_STOP_ON_FIRST_FAIL=" + stopOnFirstFail);}
-        if (not_empty(fileExtensionsToExclude)) {cmd.add("-e FILE_EXTENSIONS_TO_EXCLUDE="  + add_missing_quotes(fileExtensionsToExclude));}
+        if (not_empty(fileExtensionsToExclude)) {cmd.add("-e FILE_EXTENSIONS_TO_EXCLUDE="  + add_missing_quotes(fileExtensionsToExclude.replace("'", "\"")));}
     }
 
     public String add_missing_quotes(String str) {
-        if (!(str.startsWith("\"") && str.endsWith("\""))) {
-            str = '"' + str + '"';
+        if (!str.startsWith("\"")) {
+            str = '"' + str;
         }
+
+        if (!str.endsWith("\"")) {
+            str = str + '"';
+        }
+
         return str;
     }
 

--- a/src/main/java/io/jenkins/plugins/WallarmFastBuilder.java
+++ b/src/main/java/io/jenkins/plugins/WallarmFastBuilder.java
@@ -299,13 +299,20 @@ public class WallarmFastBuilder extends Builder implements SimpleBuildStep {
 
     public void add_testing_params(List<String> cmd) {
         cmd.add("-e CI_MODE=testing");
-        if (not_empty(testRecordId))            {cmd.add("-e TEST_RECORD_ID=" + testRecordId);}
-        if (not_empty(policyId))                {cmd.add("-e TEST_RUN_POLICY_ID=" + policyId);}
-        if (not_empty(testRunRps))              {cmd.add("-e TEST_RUN_RPS=" + testRunRps);}
-        if (not_empty(testRunName))             {cmd.add("-e TEST_RUN_NAME=" + testRunName.replace(" ", "_"));}
-        if (not_empty(testRunDesc))             {cmd.add("-e TEST_RUN_DESC=" + testRunDesc.replace(" ", "_"));}
+        if (not_empty(testRecordId))            {cmd.add("-e TEST_RECORD_ID="              + testRecordId);}
+        if (not_empty(policyId))                {cmd.add("-e TEST_RUN_POLICY_ID="          + policyId);}
+        if (not_empty(testRunRps))              {cmd.add("-e TEST_RUN_RPS="                + testRunRps);}
+        if (not_empty(testRunName))             {cmd.add("-e TEST_RUN_NAME="               + testRunName.replace(" ", "_"));}
+        if (not_empty(testRunDesc))             {cmd.add("-e TEST_RUN_DESC="               + testRunDesc.replace(" ", "_"));}
         if (not_empty(stopOnFirstFail))         {cmd.add("-e TEST_RUN_STOP_ON_FIRST_FAIL=" + stopOnFirstFail);}
-        if (not_empty(fileExtensionsToExclude)) {cmd.add("-e FILE_EXTENSIONS_TO_EXCLUDE=" + fileExtensionsToExclude);}
+        if (not_empty(fileExtensionsToExclude)) {cmd.add("-e FILE_EXTENSIONS_TO_EXCLUDE="  + add_missing_quotes(fileExtensionsToExclude));}
+    }
+
+    public String add_missing_quotes(String str) {
+        if (!(str.startsWith("\"") && str.endsWith("\""))) {
+            str = '"' + str + '"';
+        }
+        return str;
     }
 
     public void add_optional_params(List<String> cmd) {

--- a/src/main/resources/io/jenkins/plugins/WallarmFastBuilder/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/WallarmFastBuilder/config.jelly
@@ -56,7 +56,7 @@
             <f:entry title="${%Fail build}" field="failBuild" description='Fail build on completion if vulnerabilities are found'>
                 <f:checkbox />
             </f:entry>
-            <f:entry title="${%Exclude}" field="fileExtensionsToExclude" description="FAST will skip any requests to files with the extensions specified here. Use the following format: 'js|jpeg|jpg|gif|png|css'">
+            <f:entry title="${%Exclude}" field="fileExtensionsToExclude" description="FAST will skip any requests to files with the extensions specified here. Use the following format: &quot;js|jpeg|jpg|gif|png|css&quot;">
                 <f:textbox default="js|jpeg|jpg|gif|png|css"/>
             </f:entry>
         </f:nested>

--- a/src/main/resources/io/jenkins/plugins/WallarmFastBuilder/help-fileExtensionsToExclude.html
+++ b/src/main/resources/io/jenkins/plugins/WallarmFastBuilder/help-fileExtensionsToExclude.html
@@ -3,5 +3,5 @@
 
 	Leave this field blank to scan all files found.
 
-	Default: 'js|jpeg|jpg|gif|png|css'
+	Default: "js|jpeg|jpg|gif|png|css"
 </div>


### PR DESCRIPTION
spaces in file exclusion can cause problems when running the command. Surrounding the value with quotes fixes the problem